### PR TITLE
feat: 更新easypermissions版本

### DIFF
--- a/Android/config.gradle
+++ b/Android/config.gradle
@@ -17,7 +17,7 @@ ext {
             "kotlinx-coroutines-core"   : "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4",
             "kotlinx-coroutines-android": "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4",
             "fresco"                    : "com.facebook.fresco:fresco:2.6.0",
-            "easypermissions"           : "pub.devrel:easypermissions:2.0.1",
+            "easypermissions"           : "pub.devrel:easypermissions:3.0.0",
             "retrofit"                  : "com.squareup.retrofit2:retrofit:2.9.0",
             "converter-gson"            : "com.squareup.retrofit2:converter-gson:2.9.0"
     ]


### PR DESCRIPTION
项目运行失败：easypermissions 2.0.1拉取失败，更新到3.0.0版本
easypermissions README：
```
dependencies {
    // For developers using AndroidX in their applications
    implementation 'pub.devrel:easypermissions:3.0.0'
 
    // For developers using the Android Support Library
    implementation 'pub.devrel:easypermissions:2.0.1'
}
```